### PR TITLE
Remove mention of -D

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ gpio-watch
 Synopsis
 ========
 
-    gpio-watch [-D script_directory] [-e default_edge] [pin[:edge]] ...
+    gpio-watch [-s script_directory] [-e default_edge] [pin[:edge]] ...
 
 Description
 ===========
@@ -30,7 +30,7 @@ Options
 
 - `-s script_directory` -- location in which `gpio-watch` will look
   for event handling scripts.  Scripts must be named after the pin
-  number triggering the event.  For example, if you specify `-D
+  number triggering the event.  For example, if you specify `-s
   /etc/gpio-scripts`, and `gpio-watch` processes an event on pin 4, it
   will attempt to run `/etc/gpio-scripts/4`.
 

--- a/main.c
+++ b/main.c
@@ -30,7 +30,7 @@
 #include "fileutil.h"
 #include "logging.h"
 
-#define OPTSTRING "s:e:vDdl:"
+#define OPTSTRING "s:e:vdl:"
 
 #define OPT_SCRIPT_DIR		's'
 #define OPT_DEFAULT_EDGE	'e'


### PR DESCRIPTION
Remove mention of -D in README and getopts since it's not used.  Updated to -s in docs as it should be.
