### PR TITLE
<sys/time.h> needed to compile on Alpine/muslc

### DIFF
--- a/logging.c
+++ b/logging.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 #include "logging.h"


### PR DESCRIPTION
At least, it didn't compile for me without. It's the correct include according to man gettimeofday(2).
```
rm -f main.o gpio.o fileutil.o logging.o
rm -f gpio-watch
cc    -c -o main.o main.c
cc    -c -o gpio.o gpio.c
cc    -c -o fileutil.o fileutil.c
cc    -c -o logging.o logging.c
logging.c: In function 'logtime':
logging.c:40:24: error: storage size of 'tv' isn't known
         struct timeval tv;
                        ^~
logging.c:41:9: warning: implicit declaration of function 'gettimeofday' [-Wimplicit-function-declaration]
         gettimeofday(&tv, NULL);
         ^~~~~~~~~~~~
make: *** [<builtin>: logging.o] Error 1
```

With this patch:
```
rm -f main.o gpio.o fileutil.o logging.o
rm -f gpio-watch
cc    -c -o main.o main.c
cc    -c -o gpio.o gpio.c
cc    -c -o fileutil.o fileutil.c
cc    -c -o logging.o logging.c
cc  -o gpio-watch main.o gpio.o fileutil.o logging.o -lrt
```
