### PR TITLE
Make the codebase compile using -Wall, -Wpedantic and --std=c99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SRCS = main.c gpio.c fileutil.c logging.c
 OBJS = $(SRCS:.c=.o)
 LIBS = -lrt
+# _DEFAULT_SOURCE (glibc >= 2.19) for clock_gettime(),
+# strdup(), and daemon().
+CFLAGS = -Wall -Wpedantic -D_DEFAULT_SOURCE --std=c99
 INSTALL = install
 
 prefix = /usr

--- a/gpio.h
+++ b/gpio.h
@@ -44,7 +44,7 @@ struct pin {
 
 int parse_direction(const char *direction);
 int parse_edge(const char *edge);
-void pin_export(int pin);
+int pin_export(int pin);
 int pin_set_edge(int pin, int edge);
 int pin_set_direction(int pin, int direction);
 

--- a/logging.h
+++ b/logging.h
@@ -24,16 +24,16 @@
 #define LEVEL_DEBUG 3
 
 #define LOG_ERROR(fmt, ...) \
-	logprint("%s %s:%d " fmt "\n", \
-	logtime(), __FUNCTION__, __LINE__, ##__VA_ARGS__)
+	logprint("%s %s:%d " fmt "\n", logtime(), __func__, \
+    __LINE__, ##__VA_ARGS__)
 #define LOG_WARN(fmt, ...)  if (loglevel >= LEVEL_WARN)  \
-	logprint("%s %s:%d " fmt "\n", logtime(), __FUNCTION__, \
+	logprint("%s %s:%d " fmt "\n", logtime(), __func__, \
 	__LINE__, ##__VA_ARGS__)
 #define LOG_INFO(fmt, ...)  if (loglevel >= LEVEL_INFO)  \
-	logprint("%s %s:%d " fmt "\n", logtime(), __FUNCTION__, \
+	logprint("%s %s:%d " fmt "\n", logtime(), __func__, \
 	__LINE__, ##__VA_ARGS__)
 #define LOG_DEBUG(fmt, ...) if (loglevel >= LEVEL_DEBUG) \
-	logprint("%s %s:%d " fmt "\n", logtime(), __FUNCTION__, \
+	logprint("%s %s:%d " fmt "\n", logtime(), __func__, \
 	__LINE__, ##__VA_ARGS__)
 
 extern int loglevel;

--- a/main.c
+++ b/main.c
@@ -144,7 +144,7 @@ int watch_pins() {
 		fdlist[i].events = POLLPRI;
 	}
 
-	LOG_INFO("starting to monitor for gpio events");
+	LOG_INFO("starting to monitor for gpio events", NULL);
 
 	while (1) {
 		int err;
@@ -191,8 +191,6 @@ run_script:
 }
 
 int main(int argc, char **argv) {
-	struct pollfd *fdlist;
-	int numfds = 0;
 	int ch;
 	int i;
 
@@ -273,9 +271,18 @@ int main(int argc, char **argv) {
 	}
 
 	for (i=0; i<num_pins; i++) {
-		pin_export(pins[i].pin);
-		pin_set_edge(pins[i].pin, pins[i].edge);
-		pin_set_direction(pins[i].pin, DIRECTION_IN);
+		if (pin_export(pins[i].pin) != 0)
+		{
+			exit(1);
+		}
+		if (pin_set_edge(pins[i].pin, pins[i].edge) != 0)
+		{
+			exit(1);
+		}
+		if (pin_set_direction(pins[i].pin, DIRECTION_IN) != 0)
+		{
+			exit(1);
+		}
 	}
 
 	if (detach) daemon(1, logfile ? 1: 0);


### PR DESCRIPTION
While I was trying to build the APK package for Alpine, and given the fact that Alpine ran on muslc instead of glibc, I wanted to make sure that there would be no “portability” issues, so I tried to make the compiler (gcc) whine a bit more aggressively. This lead me to tweak a few bits of code, which mostly lead to a little tighter error handling, and maybe better portability.

I thought you might be interested, so here it is as a PR :)

 - Fix the warnings from GCC with `-Wall -Wpedantic --std=c99`.
 - Make GCC happy about variadic being called without an argument.
 - Make `pin_export()` return something so that we can halt on an error.
 - `-D_DEFAULT_SOURCE` is needed for some specific functions.