### PR TITLE
Added switchup mode to handle switches with pull up resistors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Options
   hardcoded as 100000 nanoseconds) after the press (rising) event to
   activate the script.
 
+  For pins with a pull-up resistor `switchup` will work the same as `switch`
+  but treats the falling edge as the press and the rising edge as the release.
+
 Example
 =======
 

--- a/gpio.c
+++ b/gpio.c
@@ -49,6 +49,8 @@ int parse_edge(const char *edge) {
 		return EDGE_BOTH;
 	else if (0 == strncmp(edge, "switch", EDGESTRLEN))
 		return EDGE_SWITCH;
+	else if (0 == strncmp(edge, "switchup", EDGESTRLEN))
+		return EDGE_SWITCH_UP;
 	else if (0 == strncmp(edge, "none", EDGESTRLEN))
 		return EDGE_NONE;
 	else
@@ -128,7 +130,7 @@ int pin_set_edge(int pin, int edge) {
 		fprintf(fp, "rising\n");
 	else if (EDGE_FALLING == edge)
 		fprintf(fp, "falling\n");
-	else if (EDGE_BOTH == edge || EDGE_SWITCH == edge)
+	else if (EDGE_BOTH == edge || EDGE_SWITCH == edge || EDGE_SWITCH_UP == edge)
 		fprintf(fp, "both\n");
 	else {
 		LOG_ERROR("pin %d: invalid edge mode (%d)",

--- a/gpio.h
+++ b/gpio.h
@@ -24,7 +24,7 @@
 #define EDGE_FALLING 2
 #define EDGE_BOTH 3
 #define EDGE_SWITCH 4
-#define EDGESTRLEN 8
+#define EDGE_SWITCH_UP 8
 
 #define DIRECTION_IN 0
 #define DIRECTION_OUT 1

--- a/main.c
+++ b/main.c
@@ -165,14 +165,18 @@ int watch_pins() {
 				// for pins use 'switch' edge mode, we only trigger
 				// an event when we receive the '1' event more than
 				// DEBOUNCE_INTERVAL nanoseconds after the '0' event.
-  				if (EDGE_SWITCH == pins[i].edge) {
+				// 'switchup' is the same but with the opposite edge 
+				// detection.
+				if (EDGE_SWITCH == pins[i].edge || EDGE_SWITCH_UP == pins[i].edge) {
+					char up = EDGE_SWITCH == pins[i].edge ? '1' : '0';
+					char down = EDGE_SWITCH == pins[i].edge ? '0' : '1';
 					clock_gettime(CLOCK_MONOTONIC, &ts);
 					now = ts.tv_sec * NANOS + ts.tv_nsec;
 
-					if (switch_state[i] == 0 && valbuf[0] == '1') {
+					if (switch_state[i] == 0 && valbuf[0] == up) {
 						down_at[i] = now;
 						switch_state[i] = 1;
-					} else if (switch_state[i] == 1 && valbuf[0] == '0') {
+					} else if (switch_state[i] == 1 && valbuf[0] == down) {
 						if (now - down_at[i] > DEBOUNCE_INTERVAL) {
 							switch_state[i] = 0;
 							goto run_script;

--- a/main.c
+++ b/main.c
@@ -168,15 +168,15 @@ int watch_pins() {
 				// 'switchup' is the same but with the opposite edge 
 				// detection.
 				if (EDGE_SWITCH == pins[i].edge || EDGE_SWITCH_UP == pins[i].edge) {
-					char up = EDGE_SWITCH == pins[i].edge ? '1' : '0';
-					char down = EDGE_SWITCH == pins[i].edge ? '0' : '1';
+					char press = EDGE_SWITCH == pins[i].edge ? '1' : '0';
+					char release = EDGE_SWITCH == pins[i].edge ? '0' : '1';
 					clock_gettime(CLOCK_MONOTONIC, &ts);
 					now = ts.tv_sec * NANOS + ts.tv_nsec;
 
-					if (switch_state[i] == 0 && valbuf[0] == up) {
+					if (switch_state[i] == 0 && valbuf[0] == press) {
 						down_at[i] = now;
 						switch_state[i] = 1;
-					} else if (switch_state[i] == 1 && valbuf[0] == down) {
+					} else if (switch_state[i] == 1 && valbuf[0] == release) {
 						if (now - down_at[i] > DEBOUNCE_INTERVAL) {
 							switch_state[i] = 0;
 							goto run_script;


### PR DESCRIPTION
'switchup' mode is needed to capture the first button press (fall then rise) when the gpio pin is configured to use the internal pull up resistor