### PR TITLE
Ignoring EM spikes and button pushes shorter than 200ms 

### DIFF
--- a/main.c
+++ b/main.c
@@ -47,8 +47,8 @@
 
 // use for converting seconds to nanoseconds.
 #define NANOS 1000000000LL
-#define DEBOUNCE_INTERVAL 200000000LL  	//minimum time the button must be pushed to execute the script
-#define IGNORE_INTERVAL 1000000L 	//ns time (1ms) to ignore everything
+#define IGNORE_INTERVAL 200000000LL  	//minimum time (200ms) the button must be pushed to execute the script
+#define DEBOUNCE_INTERVAL 1000000L 	//ns time (1ms) to ignore everything
 
 char *script_dir = DEFAULT_SCRIPT_DIR;
 char *logfile = NULL;
@@ -165,7 +165,7 @@ int watch_pins() {
 
 				// for pins use 'switch' edge mode, we only trigger
 				// an event when we receive the '1' event more than
-				// DEBOUNCE_INTERVAL nanoseconds after the '0' event.
+				// DEBOUNCE_INTERVAL + IGNORE_INTERVAL nanoseconds before the '0' event.
   				if (EDGE_SWITCH == pins[i].edge) {
 					clock_gettime(CLOCK_MONOTONIC, &ts);
 					now = ts.tv_sec * NANOS + ts.tv_nsec;
@@ -174,15 +174,15 @@ int watch_pins() {
 						down_at[i] = now;
 						switch_state[i] = 1;
 					} 
-					 else if (switch_state[i] == 1 && valbuf[0] == '0' &&(now - down_at[i] < IGNORE_INTERVAL)) {
-						//ignore here, this is the bouncing.
+					else if (switch_state[i] == 1 && valbuf[0] == '0' &&(now - down_at[i] < DEBOUNCE_INTERVAL)) {
+						//ignore everything here, this is the bouncing.
                                         }
-                                         else if (switch_state[i] == 1 && valbuf[0] == '0' &&(now - down_at[i] < DEBOUNCE_INTERVAL)) {
+                                        else if (switch_state[i] == 1 && valbuf[0] == '0' &&(now - down_at[i] < IGNORE_INTERVAL)) {
                                             	switch_state[i] = 0;
-						//button let go too early or EelctroMagnetic spike thus ignoring
+						//button let go too early or another EelctroMagnetic generated spike: resetting
                                         }
 					else if (switch_state[i] == 1 && valbuf[0] == '0') {
-						if (now - down_at[i] > DEBOUNCE_INTERVAL) {
+						if (now - down_at[i] >= IGNORE_INTERVAL) {
 							switch_state[i] = 0;
 							goto run_script;
 						}

--- a/main.c
+++ b/main.c
@@ -47,7 +47,8 @@
 
 // use for converting seconds to nanoseconds.
 #define NANOS 1000000000LL
-#define DEBOUNCE_INTERVAL 100000L
+#define DEBOUNCE_INTERVAL 200000000LL  	//minimum time the button must be pushed to execute the script
+#define IGNORE_INTERVAL 1000000L 	//ns time (1ms) to ignore everything
 
 char *script_dir = DEFAULT_SCRIPT_DIR;
 char *logfile = NULL;
@@ -172,7 +173,15 @@ int watch_pins() {
 					if (switch_state[i] == 0 && valbuf[0] == '1') {
 						down_at[i] = now;
 						switch_state[i] = 1;
-					} else if (switch_state[i] == 1 && valbuf[0] == '0') {
+					} 
+					 else if (switch_state[i] == 1 && valbuf[0] == '0' &&(now - down_at[i] < IGNORE_INTERVAL)) {
+						//ignore here, this is the bouncing.
+                                        }
+                                         else if (switch_state[i] == 1 && valbuf[0] == '0' &&(now - down_at[i] < DEBOUNCE_INTERVAL)) {
+                                            	switch_state[i] = 0;
+						//button let go too early or EelctroMagnetic spike thus ignoring
+                                        }
+					else if (switch_state[i] == 1 && valbuf[0] == '0') {
 						if (now - down_at[i] > DEBOUNCE_INTERVAL) {
 							switch_state[i] = 0;
 							goto run_script;


### PR DESCRIPTION
Code adapted to make sure that the button is pressed during minimum 200ms before the script runs. 
Original code caused to run_script after 2 voltage spikes on the concerned GPIO pin. In the original code, the first spike set "switch_state[i] = 1". Whenever there was a next spike invoking the interrupt to set "valbuf[0] == '0' "  (even after seconds or minutes ) the script ran.