### PR TITLE
Update .gitignore to ignore the compiled binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.o
 .*.sw?
+gpio-watch


### PR DESCRIPTION
`.gitignore` was not ignoring the compiled binary `gpio-watch`, which resulted in git listing it as an untracked file and made it possible to accidentally commit the binary.